### PR TITLE
Update build.properties to recent sbt version

### DIFF
--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.7
+sbt.version=1.9.1


### PR DESCRIPTION
New users may try `sbt new` and be stuck on an old version.